### PR TITLE
Use a default arg for Description

### DIFF
--- a/assh/instance.py
+++ b/assh/instance.py
@@ -9,7 +9,7 @@ class Instance:
         self.state = aws_instance["State"]["Name"]
         self.type = aws_instance["InstanceType"]
         self.image = aws_instance["ImageId"]
-        
+
         # Keyname is optional as to support SSM-only access where instances
         # may not have an attached keyname
         self.keyname = aws_instance.get("KeyName")
@@ -59,11 +59,13 @@ class Instance:
         ec2 = boto3.client("ec2")
         images = ec2.describe_images(ImageIds=[self.image])
         image = images["Images"][0]
+        # Some images come back without a Description key
+        description = image.get("Description", "").lower()
 
-        if "ubuntu" in image["Description"].lower():
+        if "ubuntu" in description:
             return "ubuntu"
 
-        if "centos" in image["Description"].lower():
+        if "centos" in description:
             return "centos"
 
         return "ec2-user"  # Default to amazon linux / RHEL default username

--- a/assh/tests/conftest.py
+++ b/assh/tests/conftest.py
@@ -87,6 +87,15 @@ def fxt_ami_centos(ec2: botostubs.EC2, public_subnet):
     yield image
 
 
+@pytest.fixture(name="ami_custom", scope="session")
+def fxt_ami_custom(ec2: botostubs.EC2, public_subnet):
+    instance = ec2.run_instances(**DEFAULT_INSTANCE_KWARGS, ImageId=IMAGE_NAME)
+    instance_id = instance["Instances"][0]["InstanceId"]
+
+    image = ec2.create_image(Name="mock_custom_application", InstanceId=instance_id)
+    yield image
+
+
 @pytest.fixture(name="public_aws_instance", scope="session")
 def fxt_public_aws_instance(ec2: botostubs.EC2, public_subnet, ami_amzn):
     new_instance = ec2.run_instances(

--- a/assh/tests/test_instance.py
+++ b/assh/tests/test_instance.py
@@ -113,6 +113,25 @@ def test_centos_username_retreival(ec2: botostubs.EC2, ami_centos, public_subnet
 
     assert instance.default_username() == "centos"
 
-def test_handles_terminated_instances_gracefully(ec2: botostubs.EC2, terminated_aws_instance):
+
+def test_no_description_username_fallback(
+    ec2: botostubs.EC2, ami_custom, public_subnet
+):
+    """Tests username resolution expecting the default fallback to ec2-user."""
+    new_instance = ec2.run_instances(
+        **DEFAULT_INSTANCE_KWARGS,
+        ImageId=ami_custom["ImageId"],
+        SubnetId=public_subnet["SubnetId"],
+    )
+    instance_id = new_instance["Instances"][0]["InstanceId"]
+    instances = ec2.describe_instances(InstanceIds=[instance_id])
+    instance = Instance(instances["Reservations"][0]["Instances"][0])
+
+    assert instance.default_username() == "ec2-user"
+
+
+def test_handles_terminated_instances_gracefully(
+    ec2: botostubs.EC2, terminated_aws_instance
+):
     """Tests that no failures are encountered when parsing terminated instances."""
     get_instances()


### PR DESCRIPTION
We're hitting images which don't have a description, and this crashes on those images, this resolves that.